### PR TITLE
Removing data-src after loading audio url

### DIFF
--- a/build/static/js/audio_test.js
+++ b/build/static/js/audio_test.js
@@ -22,6 +22,7 @@ document.addEventListener("DOMContentLoaded", function(){
 
     for(let i = 0; i < container.length; i++){
         audio_list.push(container[i].dataset.src);
+        container[i].removeAttribute('data-src');
 
         $(cur_time).text("00:00");
         $(duration).text("00:00");


### PR DESCRIPTION
Add some security to audio player - now its almost impossible to get direct file url